### PR TITLE
Use env in shbang instead of fixed shell path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ So I wrote my own. This is a middle ground for some convenience while remaining 
 * Copy bashaspec.sh to your repository
 * `myscript-spec.sh`
   ```bash
-  #!/bin/bash
+  #!/usr/bin/env bash
   test_concat() {
     a='1'
     b='2'
@@ -78,7 +78,7 @@ So I wrote my own. This is a middle ground for some convenience while remaining 
   When using other shells, if your test script changes directory (`cd`) outside of a test function, bashaspec needs to be told the path of the test file by setting the `_bashaspec_test_file` variable.  
   For example:
   ```bash
-  #!/bin/dash
+  #!/usr/bin/env dash
   cd "$(dirname "$0")" || exit 1
   _bashaspec_test_file="$(pwd)/$(basename "$0")"
   test_foo() { : ... ; }

--- a/alternate-old-versions/bashaspec-ancient.sh
+++ b/alternate-old-versions/bashaspec-ancient.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bashaspec - MIT licensed. Copyright 2020 d10n. Feel free to copy around.
 # Ancient version - all features with extra support for pre-POSIX heirloom bourne shell
 
@@ -88,7 +88,7 @@ format() {
   fi
 }
 
-# This script is #!/bin/bash, so if the shell is not bash then it must have been sourced! If the shell is bash, check.
+# This script is #!/usr/bin/env bash, so if the shell is not bash then it must have been sourced! If the shell is bash, check.
 sourced=0; [ -n "${BASH_VERSION:-}" ] && eval '! (return 0 2>/dev/null)' || sourced=1
 if [ "$sourced" -eq 0 ]; then
   run_test_files

--- a/alternate-old-versions/bashaspec-non-posix.sh
+++ b/alternate-old-versions/bashaspec-non-posix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bashaspec - MIT licensed. Copyright 2020 d10n. Feel free to copy around.
 # Non-POSIX version with equal features but only supports bash unit tests.
 

--- a/alternate-old-versions/bashaspec-non-tap.sh
+++ b/alternate-old-versions/bashaspec-non-tap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bashaspec - MIT licensed. Copyright 2020 d10n. Feel free to copy around.
 # Non-TAP version with simpler but less featureful implementation.
 

--- a/bashaspec.sh
+++ b/bashaspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # bashaspec - MIT licensed. Copyright 2020 d10n. Feel free to copy around.
 
 # Verbose? true: TAP 12 output; false: dot per test; default false
@@ -86,7 +86,7 @@ format() {
   fi
 }
 
-# This script is #!/bin/bash, so if the shell is not bash then it must have been sourced! If the shell is bash, check.
+# This script is #!/usr/bin/env bash, so if the shell is not bash then it must have been sourced! If the shell is bash, check.
 sourced=0; [ -n "${BASH_VERSION:-}" ] && ! (return 0 2>/dev/null) || sourced=1
 if [ "$sourced" -eq 0 ]; then
   run_test_files

--- a/example/example-spec.sh
+++ b/example/example-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 . ../bashaspec.sh
 

--- a/example/readme-spec.sh
+++ b/example/readme-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 . ../bashaspec.sh
 test_concat() {

--- a/tests-bash/after-all-fail-xspec.sh
+++ b/tests-bash/after-all-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/after-all-pass-xspec.sh
+++ b/tests-bash/after-all-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/after-each-fail-xspec.sh
+++ b/tests-bash/after-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/after-each-pass-xspec.sh
+++ b/tests-bash/after-each-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/before-all-fail-xspec.sh
+++ b/tests-bash/before-all-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/before-all-pass-xspec.sh
+++ b/tests-bash/before-all-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/before-and-after-each-fail-xspec.sh
+++ b/tests-bash/before-and-after-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/before-each-fail-xspec.sh
+++ b/tests-bash/before-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/before-each-pass-xspec.sh
+++ b/tests-bash/before-each-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all() {

--- a/tests-bash/hook-sequence-spec.sh
+++ b/tests-bash/hook-sequence-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 test_before_all_fail_spec() {

--- a/tests-bash/hook-state-preserved-for-tests-spec.sh
+++ b/tests-bash/hook-state-preserved-for-tests-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 before_all_run=0

--- a/tests-bash/no-hooks-pass-xspec.sh
+++ b/tests-bash/no-hooks-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 test_1() {

--- a/tests-bash/set-e-fail-after-all-xspec.sh
+++ b/tests-bash/set-e-fail-after-all-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 set -euo pipefail
 

--- a/tests-bash/set-e-fail-before-all-xspec.sh
+++ b/tests-bash/set-e-fail-before-all-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 set -euo pipefail
 

--- a/tests-bash/set-e-fail-spec.sh
+++ b/tests-bash/set-e-fail-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 set -euo pipefail
 

--- a/tests-bash/set-e-fail-test-xspec.sh
+++ b/tests-bash/set-e-fail-test-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 set -euo pipefail
 

--- a/tests-bash/set-e-pass-spec.sh
+++ b/tests-bash/set-e-pass-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 set -euo pipefail
 

--- a/tests-bash/test-return-spec.sh
+++ b/tests-bash/test-return-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 test_return_no_code_specified() {

--- a/tests-bash/test-return-xspec.sh
+++ b/tests-bash/test-return-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" || exit 1
 
 test_return_no_code_specified() {

--- a/tests-dash/after-all-fail-xspec.sh
+++ b/tests-dash/after-all-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/after-all-pass-xspec.sh
+++ b/tests-dash/after-all-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/after-each-fail-xspec.sh
+++ b/tests-dash/after-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/after-each-pass-xspec.sh
+++ b/tests-dash/after-each-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/before-all-fail-xspec.sh
+++ b/tests-dash/before-all-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/before-all-pass-xspec.sh
+++ b/tests-dash/before-all-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/before-and-after-each-fail-xspec.sh
+++ b/tests-dash/before-and-after-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/before-each-fail-xspec.sh
+++ b/tests-dash/before-each-fail-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/before-each-pass-xspec.sh
+++ b/tests-dash/before-each-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/hook-sequence-spec.sh
+++ b/tests-dash/hook-sequence-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/hook-state-preserved-for-tests-spec.sh
+++ b/tests-dash/hook-state-preserved-for-tests-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/no-hooks-pass-xspec.sh
+++ b/tests-dash/no-hooks-pass-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/set-e-fail-after-all-xspec.sh
+++ b/tests-dash/set-e-fail-after-all-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 set -eu

--- a/tests-dash/set-e-fail-before-all-xspec.sh
+++ b/tests-dash/set-e-fail-before-all-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 set -eu

--- a/tests-dash/set-e-fail-spec.sh
+++ b/tests-dash/set-e-fail-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/set-e-fail-test-xspec.sh
+++ b/tests-dash/set-e-fail-test-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 set -eu

--- a/tests-dash/set-e-pass-spec.sh
+++ b/tests-dash/set-e-pass-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 set -eu

--- a/tests-dash/test-return-spec.sh
+++ b/tests-dash/test-return-spec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 

--- a/tests-dash/test-return-xspec.sh
+++ b/tests-dash/test-return-xspec.sh
@@ -1,4 +1,4 @@
-#!/bin/dash
+#!/usr/bin/env dash
 cd "$(dirname "$0")" || exit 1
 _bashaspec_test_file="$(pwd)/$(basename "$0")"
 


### PR DESCRIPTION
Hiya, I thought I'd offer this tiny suggestion to use `env` to locate the shell instead of hardcoding the shell path as a) not all systems have `/bin/bash` for example, and b) it's plausible for users to want to use a shell from their path over the system one.